### PR TITLE
fix(client): fix breakies and stuff

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -475,7 +475,7 @@ CreateThread(function()
 		Wait(50)
 		local ped = cache.ped
 		if isPedDrivingAVehicle() then
-			vehicle = GetVehiclePedIsIn(ped, false)
+			vehicle = GetVehiclePedIsIn(ped, true)
 			vehicleClass = GetVehicleClass(vehicle)
 			healthEngineCurrent = GetVehicleEngineHealth(vehicle)
 			if healthEngineCurrent == 1000 then healthEngineLast = 1000.0 end

--- a/client.lua
+++ b/client.lua
@@ -475,7 +475,7 @@ CreateThread(function()
 		Wait(50)
 		local ped = cache.ped
 		if isPedDrivingAVehicle() then
-			vehicle = GetVehiclePedIsIn(ped, true)
+			vehicle = cache.vehicle
 			vehicleClass = GetVehicleClass(vehicle)
 			healthEngineCurrent = GetVehicleEngineHealth(vehicle)
 			if healthEngineCurrent == 1000 then healthEngineLast = 1000.0 end


### PR DESCRIPTION
## Description

Who needs breaks anyways

Proper Description
- Error saying vehicle = 0 on console no longer shows
- Vehicle breaks now work
- Max vehicle speed works
- Looks like as the error says, the whole handling file was not being loaded and then breaking all of its features.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
